### PR TITLE
docs(commands): improve command descriptions for clarity

### DIFF
--- a/src/main/java/net/pandadev/nextron/commands/GetPosCommand.java
+++ b/src/main/java/net/pandadev/nextron/commands/GetPosCommand.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class GetPosCommand extends CommandBase implements TabCompleter {
 
     public GetPosCommand() {
-        super("getposition", "Gives you the coordinates of a player", "/getposition <player>\n/getpos <player>", "nextron.getposition");
+        super("getposition", "Displays the coordinates of a player", "/getposition <player>\n/getpos <player>", "nextron.getposition");
     }
 
     @Override

--- a/src/main/java/net/pandadev/nextron/commands/GodCommand.java
+++ b/src/main/java/net/pandadev/nextron/commands/GodCommand.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class GodCommand extends CommandBase implements CommandExecutor, TabCompleter {
 
     public GodCommand() {
-        super("god", "Makes you invulnerable", "/god [player]", "nextron.god");
+        super("god", "Toggles invulnerability for a player", "/god [player]", "nextron.god");
     }
 
     @Override

--- a/src/main/java/net/pandadev/nextron/commands/HatCommand.java
+++ b/src/main/java/net/pandadev/nextron/commands/HatCommand.java
@@ -9,7 +9,7 @@ import org.bukkit.inventory.ItemStack;
 public class HatCommand extends CommandBase {
 
     public HatCommand() {
-        super("hat", "War the current item in your hand", "/hat\n/wear", "nextron.hat");
+        super("hat", "Wear the current item in your hand", "/hat\n/wear", "nextron.hat");
     }
 
     @Override

--- a/src/main/java/net/pandadev/nextron/commands/HeadCommand.java
+++ b/src/main/java/net/pandadev/nextron/commands/HeadCommand.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class HeadCommand extends CommandBase implements CommandExecutor, TabCompleter {
 
     public HeadCommand() {
-        super("head", "Gives you the head of any player", "/head <player>", "nextron.head");
+        super("head", "Gives you the head of a player", "/head <player>", "nextron.head");
     }
 
     @Override

--- a/src/main/java/net/pandadev/nextron/commands/HealCommand.java
+++ b/src/main/java/net/pandadev/nextron/commands/HealCommand.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class HealCommand extends CommandBase implements CommandExecutor, TabCompleter {
 
     public HealCommand() {
-        super("heal", "Fills up your hunger and hearts", "/heal [player]", "nextron.heal");
+        super("heal", "Fills up a player's hunger and hearts", "/heal [player]", "nextron.heal");
     }
 
     @Override

--- a/src/main/java/net/pandadev/nextron/commands/NightVisionCommand.java
+++ b/src/main/java/net/pandadev/nextron/commands/NightVisionCommand.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class NightVisionCommand extends CommandBase implements TabCompleter {
 
     public NightVisionCommand() {
-        super("nightvision", "Allows you to toggle nightivision", "/nightvision [player]\n/nv [player]", "nextron.nightvision");
+        super("nightvision", "Toggle the night vision effect for a player", "/nightvision [player]\n/nv [player]", "nextron.nightvision");
     }
 
     @Override

--- a/src/main/java/net/pandadev/nextron/commands/SudoCommand.java
+++ b/src/main/java/net/pandadev/nextron/commands/SudoCommand.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class SudoCommand extends CommandBase implements CommandExecutor, TabCompleter {
 
     public SudoCommand() {
-        super("sudo", "Forces a player to execute a command", "/sudo <player> <command>", "nextron.sudo");
+        super("sudo", "Forces a player to execute a given command", "/sudo <player> <command>", "nextron.sudo");
     }
 
     @Override

--- a/src/main/java/net/pandadev/nextron/commands/VanishCommand.java
+++ b/src/main/java/net/pandadev/nextron/commands/VanishCommand.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class VanishCommand extends CommandBase implements CommandExecutor, TabCompleter {
 
     public VanishCommand() {
-        super("vanish", "Hides you form the tab list and other players can't see you", "/vanish [player]\n/v [player]", "nextron.vanish");
+        super("vanish", "Hides you from the tab list and other players can't see you", "/vanish [player]\n/v [player]", "nextron.vanish");
     }
 
     @Override


### PR DESCRIPTION
This is non-exhaustive. There are, perhaps, some wording that can be improved. Such as:
- **toggle-ing** over **enable/disable**
- Being more verbose about commands that accept another player as parameter